### PR TITLE
Changed the removed method to the correct one

### DIFF
--- a/lib/src/injector_widget.dart
+++ b/lib/src/injector_widget.dart
@@ -51,7 +51,7 @@ class InjectorWidget extends StatefulWidget {
 
   /// Gets an [Injector] from a ]BuildContext]
   static Injector of(BuildContext context) {
-    final w = context.inheritFromWidgetOfExactType(_InjectorInheritedWidget);
+    final w = context.dependOnInheritedWidgetOfExactType<_InjectorInheritedWidget>();
     if (w == null) {
       throw InjectorWidgetError._internal(
           "No `InjectorWidget` was found in the context.");


### PR DESCRIPTION
'BuildContext' is from 'package:flutter/src/widgets/framework.dart' ('../../../flutter/packages/flutter/lib/src/widgets/framework.dart').
Try correcting the name to the name of an existing method, or defining a method named 'inheritFromWidgetOfExactType'.
    final w = context.inheritFromWidgetOfExactType(_InjectorInheritedWidget);